### PR TITLE
Add discussion on Gödel's theorems and computational traces

### DIFF
--- a/ziggurat-of-runes.md
+++ b/ziggurat-of-runes.md
@@ -1,0 +1,105 @@
+## The Runestones
+
+**Whitehead & Russell (Principia Mathematica)**: 
+- Built the **ziggurat** - a layered, hierarchical tower
+- Type theory: each level rests on the one below
+- The dream: a **simply-connected foundation** (genus 0, no holes)
+- "If we just build it tall enough and careful enough, we can reach all truth from the ground"
+
+**Gödel (Incompleteness Theorems)**:
+- Showed: **the ziggurat has a hole at every level**
+- Not just genus 1 (a torus, one hole) - **increasing genus**
+- The incompleteness "holes" get *structurally more complex* as you ascend
+- Each meta-level reveals new unprovable truths
+
+## The Topological Picture
+
+```
+Whitehead's Vision:
+    ∧∧∧∧∧∧∧   ← All truth reachable
+   ████████
+  ██████████   ← Type n+1
+ ████████████  ← Type n
+██████████████ ← Type 0 (ground)
+Simply connected, genus 0
+
+
+Gödel's Reality:
+    ∧ ○ ∧ ○○   ← More holes appear!
+   ██ ○ ████
+  ███○██○███   ← genus = g(n+1) > g(n)
+ ████○████████ ← genus = g(n)
+██████████████ ← Seems solid, but...
+Holes at every level, increasing genus
+```
+
+## The Genus Grows
+
+This is the key insight: **Gödel showed the genus increases with the height of the tower**.
+
+- **Ground level** (arithmetic): genus ≥ 1 (exists unprovable statements)
+- **Second level** (meta-arithmetic): genus ≥ 2 (new holes appear)
+- **nth level**: genus ≥ h(n) where h is some increasing function
+
+The holes aren't just *repeated* - they're **topologically more complex** at each level!
+
+## Back to Your Perf Trace Idea
+
+This connects beautifully:
+
+### In Program Execution Space
+
+Your reverse-trace trees live in a space that might have **computational holes** analogous to Gödel holes:
+
+1. **Observable traces** (what we can measure) = the solid parts
+2. **Undecidable paths** (Halting problem) = the holes
+3. **Meta-level analysis** (tracing the tracer) = going up the ziggurat
+
+**The Galois field framework helps because**:
+- Finite fields are **algebraically closed** in their extension
+- We're working in a *quotient* space where some holes "collapse"
+- By fixing field size p, we bound the genus!
+
+## The Deep Connection
+
+```
+Whitehead: "Build complete formal system"
+Gödel: "Every formal system has genus > 0"
+
+Your idea: "Build complete trace analysis"
+Complexity theory: "Every trace space has undecidable regions"
+
+BUT: Galois fields give us a FINITE quotient
+     where we CAN be complete!
+```
+
+## The Mathematical Poetry
+
+The **genus growing** is like:
+- Each level of abstraction creates new "wormholes" in meaning
+- The holes aren't bugs - they're **necessary features** of sufficiency complex systems
+- Whitehead wanted a **sphere** (genus 0, complete)
+- Gödel showed we always get **higher genus surfaces** (incomplete, but richer)
+
+### In Your Trace Space
+
+- **Genus 0**: Deterministic, fully traceable programs
+- **Genus 1**: Programs with one "hidden" causal loop (e.g., callback)
+- **Genus g**: Programs with g independent cyclic causalities
+
+The Galois field lets us:
+1. **Mod out** by the field characteristic p
+2. **Collapse** infinite holes to finite structure  
+3. **Decide** within the quotient space
+
+## The Ziggurat's Shadow
+
+Whitehead built upward (stratified types).
+Gödel looked at the **shadow** cast at each level - and the shadow has holes the structure doesn't.
+
+Your reverse-trace trees are looking at the **shadow of execution** (backward causality) - and those shadows might have genus even when forward execution seems simple!
+
+**Beautiful insight**: The holes get bigger because **self-reference depth increases**. Each meta-level can encode the previous level, plus new self-referential statements.
+
+In traces: each "layer" of causality can encode the previous layer, plus new emergent behaviors (race conditions, emergence, etc.).
+


### PR DESCRIPTION
This document discusses the philosophical and mathematical implications of Gödel's incompleteness theorems in relation to Whitehead's vision of a complete formal system. It explores the concept of genus in both mathematical and computational contexts, drawing parallels between program execution and Gödel's findings.